### PR TITLE
PB-2529: bump urllib3 to 2.7.0 (CVE-2026-44432)

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1085,14 +1085,14 @@ typing-extensions = ">=4.12.0"
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4"},
-    {file = "urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed"},
+    {file = "urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"},
+    {file = "urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c"},
 ]
 
 [package.extras]


### PR DESCRIPTION
## Summary

Bumps `urllib3` from 2.6.3 to 2.7.0 to resolve [CVE-2026-44432](https://github.com/advisories/GHSA-mf9v-mfxr-j63j).

## Vulnerability Details

**Severity**: High (8.9/10 CVSS v4)
**Affected versions**: urllib3 >= 2.6.0, < 2.7.0
**Patched version**: 2.7.0

The vulnerability allows decompression-bomb safeguards to be bypassed in parts of urllib3's streaming API, potentially causing excessive resource consumption (high CPU and memory) on the client side.

## Changes

- Updated `poetry.lock` to bump urllib3 from 2.6.3 to 2.7.0