### PR TITLE
PB-2759: Bump pytest from 8.3.5 to 9.1.1

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -974,27 +974,43 @@ files = [
 ]
 
 [[package]]
-name = "pytest"
-version = "8.3.5"
-description = "pytest: simple powerful testing with Python"
+name = "pygments"
+version = "2.20.0"
+description = "Pygments is a syntax highlighting package written in Python."
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 groups = ["dev"]
 files = [
-    {file = "pytest-8.3.5-py3-none-any.whl", hash = "sha256:c69214aa47deac29fad6c2a4f590b9c4a9fdb16a403176fe154b79c0b4d4d820"},
-    {file = "pytest-8.3.5.tar.gz", hash = "sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845"},
+    {file = "pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176"},
+    {file = "pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f"},
+]
+
+[package.extras]
+windows-terminal = ["colorama (>=0.4.6)"]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+description = "pytest: simple powerful testing with Python"
+optional = false
+python-versions = ">=3.10"
+groups = ["dev"]
+files = [
+    {file = "pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c"},
+    {file = "pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313"},
 ]
 
 [package.dependencies]
-colorama = {version = "*", markers = "sys_platform == \"win32\""}
-exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
-iniconfig = "*"
-packaging = "*"
+colorama = {version = ">=0.4", markers = "sys_platform == \"win32\""}
+exceptiongroup = {version = ">=1", markers = "python_version < \"3.11\""}
+iniconfig = ">=1.0.1"
+packaging = ">=22"
 pluggy = ">=1.5,<2"
+pygments = ">=2.7.2"
 tomli = {version = ">=1", markers = "python_version < \"3.11\""}
 
 [package.extras]
-dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
+dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "requests", "setuptools", "xmlschema"]
 
 [[package]]
 name = "python-dateutil"
@@ -1289,4 +1305,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = "<4, >=3.10"
-content-hash = "474ddee243cba83719e50bd23f69dfba34c87772086772ffff259d9798651099"
+content-hash = "01aea4b72ae70f546aae2d12fb61383a027ad21b804b3e61059453160baedad5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
 
 [tool.poetry.group.dev.dependencies]
 openapi-generator-cli = "^7.12.0"
-pytest = "^8.3.4"
+pytest = "^9.0.3"
 flake8 = "^7.1.1"
 black = "^26.3.1"
 


### PR DESCRIPTION
# Description

PB-2759: Bump pytest from 8.3.5 to 9.1.1

The constraint in `pyproject.toml` moves from `^8.3.4` to `^9.0.3` and the lock file resolves to pytest 9.1.1.

## Compatibility checks

pytest 9 is a major release, so the main risk is breakage in how the suite is collected and run. Checks done:

- pytest 9.1.1 requires Python `>=3.10`, which matches the project's existing `requires-python` floor, so no supported Python version is dropped.
- The full suite (35 tests) passes under pytest 9.1.1.
- The suite also passes with `-W error`, so no deprecation warnings are being raised and nothing is queued to break in a future pytest 10.

## Impact

Development-only (`tool.poetry.group.dev.dependencies`) change; runtime dependencies are untouched, so nothing changes for consumers of the published client.