### PR TITLE
PB-2758: Bump idna from 3.10 to 3.15

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -464,18 +464,18 @@ files = [
 
 [[package]]
 name = "idna"
-version = "3.10"
+version = "3.15"
 description = "Internationalized Domain Names in Applications (IDNA)"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.8"
 groups = ["main"]
 files = [
-    {file = "idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3"},
-    {file = "idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9"},
+    {file = "idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8"},
+    {file = "idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc"},
 ]
 
 [package.extras]
-all = ["flake8 (>=7.1.1)", "mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2)"]
+all = ["mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2)"]
 
 [[package]]
 name = "iniconfig"


### PR DESCRIPTION
Dependency bump of `idna` from 3.10 to 3.15. `idna` is a transitive dependency, so only `poetry.lock` changes; `pyproject.toml` is untouched.

## Checks
(these are Claude assisted - asked to go through changelog)

Reviewed the [changelog for 3.11–3.15](https://github.com/kjd/idna/blob/master/HISTORY.md). Nothing in it touches how this client uses the library:

- **3.11/3.12**: Unicode data updates (16.0.0, then 17.0.0). Only affects encoding of edge-case internationalised domain names; our resource endpoints are plain ASCII hostnames.
- **3.12**: `transitional` argument deprecated and lazy-loading added. We never call `idna` directly, so the deprecation cannot reach us, and lazy-loading is a minor import-time improvement.
- **3.13**: Single codepoint classification fix (U+A7F1).
- **3.14/3.15**: Oversize inputs (labels/domains beyond DNS length limits) are now rejected up-front rather than processed. This is the only behavioural change of note - it only affects hostnames that were already invalid per DNS length rules, so no impact here.
- Minimum Python is now 3.8 (was 3.6), well below what this project requires.

## Testing

- Full test suite passes against the updated lock (35 passed).

